### PR TITLE
feat: [SEISMO - 0016,0017] Change WRITE and AUTHORIZATION handling

### DIFF
--- a/libdali/connection.c
+++ b/libdali/connection.c
@@ -287,7 +287,7 @@ dl_authorize (DLCP *dlconn, char *jwt, int *pstatuscode)
   if (replylen <= 0)
   {
     // reply should always contain something from ringserver
-    dl_log_r (dlconn, 2, 0, "[%s] dl_authorize(): problem sending AUTHORIZATION command\n",
+    dl_log_r (dlconn, 2, 0, "[%s] dl_authorize(): problem within AUTHORIZATION step\n",
               dlconn->addr);
     return -1;
   }

--- a/libdali/libdali.h
+++ b/libdali/libdali.h
@@ -271,10 +271,10 @@ extern int     dl_exchangeIDs (DLCP *dlconn, int parseresp);
 extern int64_t dl_position (DLCP *dlconn, int64_t pktid, dltime_t pkttime);
 extern int64_t dl_position_after (DLCP *dlconn, dltime_t datatime);
 extern int64_t dl_match (DLCP *dlconn, char *matchpattern);
-extern int64_t dl_authorize (DLCP *dlconn, char *jwt);
+extern int64_t dl_authorize (DLCP *dlconn, char *jwt, int *pstatuscode);
 extern int64_t dl_reject (DLCP *dlconn, char *rejectpattern);
 extern int64_t dl_write (DLCP *dlconn, void *packet, int packetlen, char *streamid,
-			 dltime_t datastart, dltime_t dataend, int ack);
+			 dltime_t datastart, dltime_t dataend, int ack, int *pstatuscode);
 extern int     dl_read (DLCP *dlconn, int64_t pktid, DLPacket *packet,
 			void *packetdata, size_t maxdatasize);
 extern int     dl_getinfo (DLCP *dlconn, const char *infotype, char *infomatch,

--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -1,0 +1,83 @@
+#ifndef RINGSERVER_RESPONSE_CODES_H
+#define RINGSERVER_RESPONSE_CODES_H
+
+/* Status Code Format: XYZ
+ * X : 0-n based on response group (ie GENERIC is 0, WRITE is 1, AUTH(ORIZATION) is 2, and so on)
+ * Y : 0-n increments as type changes within a response group
+ * Z : 0 if success type, 1 if error type
+ *
+ * For example:
+ * 210 :
+ * 2 = AUTHENTICATION group
+ * 1 = 1st type of response within authentication group  (note: types start at 0 / 0th)
+ * 0 = Success code
+ *
+ * Note: Always use the most specific and apt status code for your scenario
+ */
+
+// Define constant integer values for response status codes
+#define GENERIC_SUCCESS                   0
+#define GENERIC_ERROR                     1
+
+#define WRITE_SUCCESS                     100  // Catch all success
+                                               // Action: Continue
+#define WRITE_ERROR                       101  // Catch all error
+                                               // Action: Disconnect
+#define WRITE_INTERNAL_ERROR              111  // Error due to error in ringserver, when there's nothing slink2dali can do about
+                                               // Action: Disconnect
+#define WRITE_UNAUTHORIZED_ERROR          121  // Client has no write permission (token)
+                                               // Action: Disconnect
+#define WRITE_STREAM_UNAUTHORIZED_ERROR   131  // Client has write permission (token) but doesn't authorize write on this stream
+                                               // Action: continue with next (pkt was dropped)
+                                               // Important for brgy's that forward mixed
+                                               // packets
+#define WRITE_NO_DEVICE_ERROR             141  // Client has write permission (token) but has no specified device to write on
+                                               // Action: Disconnect
+#define WRITE_EXPIRED_TOKEN_ERROR         151  // Client's write permission (token) is expired
+                                               // Action: Disconnect
+#define WRITE_FORMAT_ERROR                161  // Error in write command formatting leading to parsing error                                              
+                                               // Action: Disconnect
+#define WRITE_LARGE_PACKET_ERROR          171  // Packet is larger than ring packet size
+                                               // Action: Disconnect (should we just drop?)
+
+#define AUTH_SUCCESS                      200  // Catch all success
+                                               // Action: Continue
+#define AUTH_ERROR                        201  // Catch all error
+                                               // Action: Retry N times, disconnect
+#define AUTH_INTERNAL_ERROR               211  // Error due to error within ringserver processes
+                                               // Action: Retry N times, disconnect
+#define AUTH_TOKEN_SIZE_ERROR             221  // Size of token isn't as expected (ie too large)
+                                               // Action: Disconnect
+#define AUTH_INVALID_TOKEN_ERROR          231  // Token is not a valid token from AuthServer
+                                               // Action: Disconnect
+#define AUTH_ROLE_INVALID_ERROR           241  // Role in token isn't what's expected (ie should be sensor)
+                                               // Action: Disconnect
+#define AUTH_EXPIRED_TOKEN_ERROR          251  // Token is expired
+                                               // Action: Disconnect
+#define AUTH_FORMAT_ERROR                 261  // Error in auth command formatting (ie no args given)
+                                               // Action: Disconnect
+
+// Define response codes as strings
+#define GENERIC_SUCCESS_STR                  "GENERIC_SUCCESS"
+#define GENERIC_ERROR_STR                    "GENERIC_ERROR"
+
+#define WRITE_SUCCESS_STR                    "WRITE_SUCCESS"
+#define WRITE_ERROR_STR                      "WRITE_ERROR"
+#define WRITE_INTERNAL_ERROR_STR             "WRITE_INTERNAL_ERROR"
+#define WRITE_UNAUTHORIZED_ERROR_STR         "WRITE_UNAUTHORIZED_ERROR"
+#define WRITE_STREAM_UNAUTHORIZED_ERROR_STR  "WRITE_STREAM_UNAUTHORIZED_ERROR"
+#define WRITE_NO_DEVICE_ERROR_STR            "WRITE_NO_DEVICE_ERROR"
+#define WRITE_EXPIRED_TOKEN_ERROR_STR        "WRITE_EXPIRED_TOKEN_ERROR"
+#define WRITE_FORMAT_ERROR_STR               "WRITE_FORMAT_ERROR"
+#define WRITE_LARGE_PACKET_ERROR_STR         "WRITE_LARGE_PACKET_ERROR"
+
+#define AUTH_SUCCESS_STR                     "AUTH_SUCCESS"
+#define AUTH_ERROR_STR                       "AUTH_ERROR"
+#define AUTH_INTERNAL_ERROR_STR              "AUTH_INTERNAL_ERROR"
+#define AUTH_TOKEN_SIZE_ERROR_STR            "AUTH_TOKEN_SIZE_ERROR"
+#define AUTH_INVALID_TOKEN_ERROR_STR         "AUTH_INVALID_TOKEN_ERROR"
+#define AUTH_ROLE_INVALID_ERROR_STR          "AUTH_ROLE_INVALID_ERROR"
+#define AUTH_EXPIRED_TOKEN_ERROR_STR         "AUTH_EXPIRED_TOKEN_ERROR"
+#define AUTH_FORMAT_ERROR_STR                "AUTH_FORMAT_ERROR"
+
+#endif  /* RINGSERVER_RESPONSE_CODES_H */

--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -16,8 +16,8 @@
  */
 
 // Define constant integer values for response status codes
-#define GENERIC_SUCCESS                   0
-#define GENERIC_ERROR                     1
+#define GENERIC_RINGSERVER_SUCCESS        0
+#define GENERIC_RINGSERVER_ERROR          1
 
 #define WRITE_SUCCESS                     100  // Catch all success
                                                // Action: Continue
@@ -58,8 +58,8 @@
                                                // Action: Disconnect
 
 // Define response codes as strings
-#define GENERIC_SUCCESS_STR                  "GENERIC_SUCCESS"
-#define GENERIC_ERROR_STR                    "GENERIC_ERROR"
+#define GENERIC_RINGSERVER_SUCCESS_STR       "GENERIC_RINGSERVER_SUCCESS"
+#define GENERIC_RINGSERVER_ERROR_STR         "GENERIC_RINGSERVER_ERROR"
 
 #define WRITE_SUCCESS_STR                    "WRITE_SUCCESS"
 #define WRITE_ERROR_STR                      "WRITE_ERROR"


### PR DESCRIPTION
<!--- Add title with the following format,

type: [SEISMO-XXXX] SHORTENED TASK TITLE

where type is:
1. draft - to be completed PR
2. feat - new feature
3. fix - bug fixes
4. test - unit tests
5. chore - (aka housekeeping) cleaning/styling/refactor code, documentations, adding comments
--> 

# Detailed Description

### Summary
<!--- Please link the related issue/task --> 
> This PR fixes: [SEISMO 0016 - Change reconnect routines](https://www.notion.so/jeffsanchez/ISSUE-0016-303eff0b880243e89e3199cfe3321c28?pvs=4)
> This PR fixes: [SEISMO 0017 - Follow standard error codes](https://www.notion.so/jeffsanchez/ISSUE-0017-902fffa8b4064666b828370fd6a5236d?pvs=4)

<!--- Please include a detailed summary of the changes --> 
 - Status codes are defined as macros in `ringserver_response_codes.h` to provide a standard code for each error/success scenario.
 - `dl_write()` was changed to expect a format of `STATUS_CODE_STR(STATUS_CODE_NUM): Error message` for every error reply from RingServer. The `STATUS_CODE_NUM` are then parsed into a variable accessible to the caller. 
 - A similar change as above was performed on `dl_authorize`
 - `sendrecord()` was edited and `createDLconnection()` was created in slink2dali.c to:
    1. access the status codes from dl_write and dl_authorize
    2. make the code execution flow depend on the status codes

### Motivation & Context
This change was performed to redefine the execution of slink2dali: previously it will infinitely retry to forward data whenever errors are encountered, now it is a one-fire attempt where it'll just stop when a critical failure was encountered. This opens for more fine-grained control to be done in the future. 

### Type of change
<!--- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!--- If breaking change, detail which existing functionality/s should or is expected to change -->


# How Has This Been Tested?
<!--- Remove this section if not applicable -->
So far, only the following three cases have been tested:
1. Running without token
![image](https://github.com/UPRI-earthquake/sender-slink2dali/assets/47804913/09062b71-1d7c-493c-b338-5d18f2b5da28)

2. When an INTERNAL_ERROR is encountered
<div>
  <img src="https://github.com/UPRI-earthquake/sender-slink2dali/assets/47804913/fef28f7c-b397-4b50-9b4c-0754713b71d0" alt="slink2dali" width="400" />
  <img src="https://github.com/UPRI-earthquake/sender-slink2dali/assets/47804913/4199e683-44e4-4764-b6f2-d69410f01dbc" alt="ringserver" width="400" />
</div>

3. Successful forwarding
<div>
  <img src="https://github.com/UPRI-earthquake/sender-slink2dali/assets/47804913/eaf42fab-ae5d-4e9d-96b0-190aa5ce6009" alt="slink2dali" width="400" />
  <img src="https://github.com/UPRI-earthquake/sender-slink2dali/assets/47804913/62a3c1d0-005b-479c-82bb-31734eabd4c4" alt="ringserver" width="400" />
</div>

# Checklist:
<!--- Double check the following and leave uncheck those that you haven't done or are not applicable. -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
