### PR TITLE
feat: [SEISMO-0086] - Minor response code addition

### DIFF
--- a/src/ringserver_response_codes.h
+++ b/src/ringserver_response_codes.h
@@ -39,6 +39,9 @@
                                                // Action: Disconnect
 #define WRITE_LARGE_PACKET_ERROR          171  // Packet is larger than ring packet size
                                                // Action: Disconnect (should we just drop?)
+#define WRITE_DUPLICATE_PACKET_ERROR      181  // Packet has an overlap in ring, based on datastart and dataend times
+                                               // Action: continue with next (pkt was dropped)
+
 
 #define AUTH_SUCCESS                      200  // Catch all success
                                                // Action: Continue
@@ -70,6 +73,7 @@
 #define WRITE_EXPIRED_TOKEN_ERROR_STR        "WRITE_EXPIRED_TOKEN_ERROR"
 #define WRITE_FORMAT_ERROR_STR               "WRITE_FORMAT_ERROR"
 #define WRITE_LARGE_PACKET_ERROR_STR         "WRITE_LARGE_PACKET_ERROR"
+#define WRITE_DUPLICATE_PACKET_ERROR_STR     "WRITE_DUPLICATE_PACKET_ERROR"
 
 #define AUTH_SUCCESS_STR                     "AUTH_SUCCESS"
 #define AUTH_ERROR_STR                       "AUTH_ERROR"

--- a/src/slink2dali.c
+++ b/src/slink2dali.c
@@ -323,10 +323,11 @@ sendrecord (char *record, int reclen)
   }
   else
   {
-    sl_log (2, 0, "Error on dl_write() \n");
 
     switch(write_status){
       case WRITE_STREAM_UNAUTHORIZED_ERROR:
+      case WRITE_DUPLICATE_PACKET_ERROR:
+        sl_log (2, 0, "Warning on dl_write() \n");
         return -1;
       case WRITE_ERROR:
       case WRITE_INTERNAL_ERROR:
@@ -336,6 +337,7 @@ sendrecord (char *record, int reclen)
       case WRITE_FORMAT_ERROR:
       case WRITE_LARGE_PACKET_ERROR:
       default:
+        sl_log (2, 0, "Error on dl_write() \n");
         return -2; // disconnect
     }
   }


### PR DESCRIPTION
Minor PR to handle new response code for duplicate packet write attempt on RingServer.

See corresponding [PR on RingServer](https://github.com/UPRI-earthquake/receiver-ringserver/pull/6).